### PR TITLE
Revert BlazorMonaco update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageVersion Include="Basic.Reference.Assemblies.AspNet90" Version="1.8.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
-    <PackageVersion Include="BlazorMonaco" Version="3.3.0" />
+    <PackageVersion Include="BlazorMonaco" Version="3.2.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="ICSharpCode.Decompiler" Version="9.0.0.7889" />
     <PackageVersion Include="KristofferStrube.Blazor.WebWorkers" Version="0.1.0-alpha.7" />

--- a/src/App/Lab/LanguageServices.cs
+++ b/src/App/Lab/LanguageServices.cs
@@ -48,9 +48,10 @@ internal sealed class LanguageServices(IJSRuntime jsRuntime, WorkerController wo
     public async Task RegisterAsync()
     {
         var cSharpLanguageSelector = new LanguageSelector("csharp");
-        await BlazorMonaco.Languages.Global.RegisterCompletionItemProvider(jsRuntime, cSharpLanguageSelector, new(
-            triggerCharacters: [" ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", ">", "~"],
-            provideCompletionItems: (modelUri, position, context) =>
+        await CompletionItemProviderAsync.Register(jsRuntime, cSharpLanguageSelector, new()
+        {
+            TriggerCharacters = [" ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", ">", "~"],
+            ProvideCompletionItemsFunc = (modelUri, position, context) =>
             {
                 return DebounceAsync(
                     ref completionCts,
@@ -58,7 +59,8 @@ internal sealed class LanguageServices(IJSRuntime jsRuntime, WorkerController wo
                     new() { Suggestions = [], Incomplete = true },
                     args => worker.ProvideCompletionItemsAsync(args.modelUri, args.position, args.context));
             },
-            resolveCompletionItem: (completionItem) => Task.FromResult(completionItem)));
+            ResolveCompletionItemFunc = (completionItem) => Task.FromResult(completionItem),
+        });
     }
 
     public void OnDidChangeWorkspace(ImmutableArray<ModelInfo> models)

--- a/src/App/Utils/Monaco/CompletionItemProviderAsync.cs
+++ b/src/App/Utils/Monaco/CompletionItemProviderAsync.cs
@@ -1,0 +1,42 @@
+﻿using BlazorMonaco;
+using BlazorMonaco.Languages;
+using Microsoft.JSInterop;
+
+namespace DotNetLab;
+
+/// <summary>
+/// <see href="https://github.com/serdarciplak/BlazorMonaco/issues/124"/>
+/// </summary>
+internal sealed class CompletionItemProviderAsync
+{
+    public delegate Task<CompletionList> ProvideCompletionItemsDelegate(string modelUri, Position position, CompletionContext context);
+
+    public delegate Task<CompletionItem> ResolveCompletionItemDelegate(CompletionItem completionItem);
+
+    public static ValueTask Register(IJSRuntime jsRuntime, LanguageSelector language, CompletionItemProviderAsync completionItemProvider)
+    {
+        return jsRuntime.InvokeVoidAsync(
+            "blazorMonaco.languages.registerCompletionItemProvider",
+            language,
+            completionItemProvider.TriggerCharacters,
+            DotNetObjectReference.Create(completionItemProvider));
+    }
+
+    public List<string>? TriggerCharacters { get; init; }
+
+    public required ProvideCompletionItemsDelegate ProvideCompletionItemsFunc { get; init; }
+
+    public required ResolveCompletionItemDelegate ResolveCompletionItemFunc { get; init; }
+
+    [JSInvokable]
+    public Task<CompletionList> ProvideCompletionItems(string modelUri, Position position, CompletionContext context)
+    {
+        return ProvideCompletionItemsFunc(modelUri, position, context);
+    }
+
+    [JSInvokable]
+    public Task<CompletionItem> ResolveCompletionItem(CompletionItem completionItem)
+    {
+        return ResolveCompletionItemFunc.Invoke(completionItem);
+    }
+}


### PR DESCRIPTION
This reverts commit c61013e4232dcde1708831752a7666390b19a97d.

Second attempt to fix broken VIM (see https://github.com/jjonescz/DotNetLab/pull/56 for the first attempt which at the time I thought worked but it didn't).