### PR TITLE
Execute original Task main method

### DIFF
--- a/src/Compiler/Compiler.cs
+++ b/src/Compiler/Compiler.cs
@@ -366,12 +366,12 @@ public sealed class Compiler(
                 {
                     Type = "run",
                     Label = "Run",
-                    LazyText = () =>
+                    LazyText = async () =>
                     {
                         string output = tryGetEmitStream(getExecutableCompilation(), out var emitStream, out var error)
-                            ? Executor.Execute(emitStream, references.Assemblies)
+                            ? await Executor.ExecuteAsync(emitStream, references.Assemblies)
                             : error;
-                        return new(output);
+                        return output;
                     },
                     Priority = 1,
                 },
@@ -454,7 +454,7 @@ public sealed class Compiler(
             var entryPoint = configAssembly.EntryPoint
                 ?? throw new ArgumentException("No entry point found in the configuration assembly.");
 
-            Executor.InvokeEntryPoint(entryPoint);
+            Executor.InvokeEntryPointAsync(entryPoint);
 
             return true;
         }

--- a/src/Shared/Executor.cs
+++ b/src/Shared/Executor.cs
@@ -1,14 +1,16 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Threading.Tasks;
 
 namespace DotNetLab;
 
 public static class Executor
 {
-    public static string Execute(MemoryStream emitStream, ImmutableArray<RefAssembly> assemblies)
+    public static async Task<string> ExecuteAsync(MemoryStream emitStream, ImmutableArray<RefAssembly> assemblies)
     {
         var alc = new ExecutorLoader(assemblies);
         try
@@ -19,20 +21,19 @@ public static class Executor
                 ?? throw new ArgumentException("No entry point found in the assembly.");
 
             int exitCode = 0;
-            Util.CaptureConsoleOutput(
-                () =>
+            (string stdout, string stderr) = await Util.CaptureConsoleOutputAsync(
+                async () =>
                 {
                     try
                     {
-                        exitCode = InvokeEntryPoint(entryPoint);
+                        exitCode = await InvokeEntryPointAsync(entryPoint);
                     }
                     catch (TargetInvocationException e)
                     {
                         Console.Error.WriteLine($"Unhandled exception. {e.InnerException ?? e}");
                         exitCode = unchecked((int)0xE0434352);
                     }
-                },
-                out string stdout, out string stderr);
+                });
 
             return $"Exit code: {exitCode}\nStdout:\n{stdout}\nStderr:\n{stderr}";
         }
@@ -46,12 +47,65 @@ public static class Executor
         }
     }
 
-    public static int InvokeEntryPoint(MethodInfo entryPoint)
+    public static async Task<int> InvokeEntryPointAsync(MethodInfo entryPoint)
     {
+        entryPoint = GetEntryPoint(entryPoint);
         var parameters = entryPoint.GetParameters().Length == 0
             ? null
             : new object[] { Array.Empty<string>() };
-        return entryPoint.Invoke(null, parameters) is int e ? e : 0;
+        var @return = entryPoint.Invoke(null, parameters);
+        switch (@return)
+        {
+            case Task<int> taskInt:
+                @return = await taskInt.ConfigureAwait(false);
+                break;
+            case Task task:
+                await task.ConfigureAwait(false);
+                @return = 0;
+                break;
+            case ValueTask<int> valueTaskInt:
+                @return = await valueTaskInt.ConfigureAwait(false);
+                break;
+            case ValueTask valueTask:
+                await valueTask.ConfigureAwait(false);
+                @return = 0;
+                break;
+        }
+        return @return is int e ? e : 0;
+        static MethodInfo GetEntryPoint(MethodInfo main)
+        {
+            try
+            {
+                var bytes = main.GetMethodBody()?.GetILAsByteArray();
+                var method = bytes switch
+                {
+                    [
+                        (byte)ILOpCode.Ldarg_0,
+                        (byte)ILOpCode.Call, _, _, _, _,
+                        (byte)ILOpCode.Callvirt, _, _, _, _,
+                        (byte)ILOpCode.Stloc_0,
+                        (byte)ILOpCode.Ldloca_s, 0,
+                        (byte)ILOpCode.Call, _, _, _, _,
+                        (byte)ILOpCode.Ret
+                    ] => main.Module.ResolveMethod(BitConverter.ToInt32(bytes.AsSpan(2, 4))),
+                    [
+                        (byte)ILOpCode.Call, _, _, _, _,
+                        (byte)ILOpCode.Callvirt, _, _, _, _,
+                        (byte)ILOpCode.Stloc_0,
+                        (byte)ILOpCode.Ldloca_s, 0,
+                        (byte)ILOpCode.Call, _, _, _, _,
+                        (byte)ILOpCode.Ret
+                    ] => main.Module.ResolveMethod(BitConverter.ToInt32(bytes.AsSpan(1, 4))),
+                    _ => null,
+                };
+                if (method is MethodInfo { ReturnType: Type type } info && (type == typeof(Task) || type.IsSubclassOf(typeof(Task))))
+                {
+                    return info;
+                }
+            }
+            catch { }
+            return main;
+        }
     }
 
     public static async Task<string> RenderComponentToHtmlAsync(MemoryStream emitStream, string componentTypeName)

--- a/src/Shared/Util.cs
+++ b/src/Shared/Util.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
 
 namespace DotNetLab;
 
@@ -118,7 +119,7 @@ public static partial class Util
         }
     }
 
-    public static void CaptureConsoleOutput(Action action, out string stdout, out string stderr)
+    public static async Task<(string stdout, string stderr)> CaptureConsoleOutputAsync(Func<Task> action)
     {
         using var stdoutWriter = new StringWriter();
         using var stderrWriter = new StringWriter();
@@ -128,15 +129,16 @@ public static partial class Util
         Console.SetError(stderrWriter);
         try
         {
-            action();
+            await action();
         }
         finally
         {
-            stdout = stdoutWriter.ToString();
-            stderr = stderrWriter.ToString();
             Console.SetOut(originalOut);
             Console.SetError(originalError);
         }
+        var stdout = stdoutWriter.ToString();
+        var stderr = stderrWriter.ToString();
+        return (stdout, stderr);
     }
 
     public static async IAsyncEnumerable<T> Concat<T>(this IAsyncEnumerable<T> a, IEnumerable<T> b)


### PR DESCRIPTION
Since `net-browser` does not support wait on monitors, it cannot run `Task` main in default.

![image](https://github.com/user-attachments/assets/b451acdc-c35c-458d-8575-50ab1a887960)

So, I read the IL of the compiler generated main method to get the original main method and `await` it.

```cs
public static async Task<int> InvokeEntryPointAsync(MethodInfo entryPoint)
{
    entryPoint = GetEntryPoint(entryPoint);
    var parameters = entryPoint.GetParameters().Length == 0
        ? null
        : new object[] { Array.Empty<string>() };
    var @return = entryPoint.Invoke(null, parameters);
    switch (@return)
    {
        case Task<int> taskInt:
            @return = await taskInt.ConfigureAwait(false);
            break;
        case Task task:
            await task.ConfigureAwait(false);
            @return = 0;
            break;
        case ValueTask<int> valueTaskInt:
            @return = await valueTaskInt.ConfigureAwait(false);
            break;
        case ValueTask valueTask:
            await valueTask.ConfigureAwait(false);
            @return = 0;
            break;
    }
    return @return is int e ? e : 0;
    static MethodInfo GetEntryPoint(MethodInfo main)
    {
        try
        {
            var bytes = main.GetMethodBody()?.GetILAsByteArray();
            var method = bytes switch
            {
                [
                    (byte)ILOpCode.Ldarg_0,
                    (byte)ILOpCode.Call, _, _, _, _,
                    (byte)ILOpCode.Callvirt, _, _, _, _,
                    (byte)ILOpCode.Stloc_0,
                    (byte)ILOpCode.Ldloca_s, 0,
                    (byte)ILOpCode.Call, _, _, _, _,
                    (byte)ILOpCode.Ret
                ] => main.Module.ResolveMethod(BitConverter.ToInt32(bytes.AsSpan(2, 4))),
                [
                    (byte)ILOpCode.Call, _, _, _, _,
                    (byte)ILOpCode.Callvirt, _, _, _, _,
                    (byte)ILOpCode.Stloc_0,
                    (byte)ILOpCode.Ldloca_s, 0,
                    (byte)ILOpCode.Call, _, _, _, _,
                    (byte)ILOpCode.Ret
                ] => main.Module.ResolveMethod(BitConverter.ToInt32(bytes.AsSpan(1, 4))),
                _ => null,
            };
            if (method is MethodInfo { ReturnType: Type type } info && (type == typeof(Task) || type.IsSubclassOf(typeof(Task))))
            {
                return info;
            }
        }
        catch { }
        return main;
    }
}
```

It works fine now.

![image](https://github.com/user-attachments/assets/1de95e58-4235-49dc-9cfe-b03e2a602e90)